### PR TITLE
cAddMenuItem expects "disabled" argument

### DIFF
--- a/trayhost_generic.go
+++ b/trayhost_generic.go
@@ -6,5 +6,5 @@ import "C"
 
 func addMenuItem(id int, item MenuItem) {
 	enabled := (item.Enabled == nil) || item.Enabled()
-	cAddMenuItem((C.int)(id), C.CString(item.Title), cbool(enabled))
+	cAddMenuItem((C.int)(id), C.CString(item.Title), cbool(!enabled))
 }


### PR DESCRIPTION
The cAddMenuItem signature expects a bool that is true when the item is disabled, false otherwise. Thus, flip the enabled bool to accommodate. 