### PR TITLE
OS X support to get clipboard files.

### DIFF
--- a/platform/common.h
+++ b/platform/common.h
@@ -2,13 +2,18 @@
 #define __common_H__
 
 struct image {
-    char        kind;
-    const void* bytes;
-    int         length;
+    char         kind;
+    const void * bytes;
+    int          length;
 };
 
 #define IMAGE_KIND_NONE (0)
 #define IMAGE_KIND_PNG  (1)
 #define IMAGE_KIND_TIFF (2)
+
+struct files {
+    const char ** names;
+    int           count;
+};
 
 #endif // __common_H__

--- a/platform/common.h
+++ b/platform/common.h
@@ -13,7 +13,7 @@ struct files {
 };
 
 struct clipboard_content {
-	const char * text;
+    const char * text;
     struct image image;
     struct files files;
 };

--- a/platform/common.h
+++ b/platform/common.h
@@ -2,18 +2,20 @@
 #define __common_H__
 
 struct image {
-    char         kind;
+    const char * kind; // File extension in lower case: "png", "jpg", "tiff", etc. Empty string means no image.
     const void * bytes;
     int          length;
 };
 
-#define IMAGE_KIND_NONE (0)
-#define IMAGE_KIND_PNG  (1)
-#define IMAGE_KIND_TIFF (2)
-
 struct files {
     const char ** names;
     int           count;
+};
+
+struct clipboard_content {
+	const char * text;
+    struct image image;
+    struct files files;
 };
 
 #endif // __common_H__

--- a/platform/darwin/tray.m
+++ b/platform/darwin/tray.m
@@ -166,7 +166,15 @@ struct image get_clipboard_image() {
     img.length = 0;
 
     // TODO: Fix memory leak.
-    if ([[pasteboard types] containsObject:NSPasteboardTypePNG] &&
+    /*if ([[pasteboard types] containsObject:NSFilenamesPboardType] &&
+        (object = [pasteboard dataForType:NSFilenamesPboardType]) != NULL) {
+
+        //NSArray * filenames = [pasteboard propertyListForType:NSFilenamesPboardType];
+
+        NSLog(@"stringForType = %@", [pasteboard stringForType:NSFilenamesPboardType]);
+
+        img.kind = 56;
+    } else */if ([[pasteboard types] containsObject:NSPasteboardTypePNG] &&
         (object = [pasteboard dataForType:NSPasteboardTypePNG]) != NULL) {
 
         img.kind = IMAGE_KIND_PNG;
@@ -182,6 +190,95 @@ struct image get_clipboard_image() {
 
     return img;
 }
+
+/*struct image get_clipboard_file() {
+    NSPasteboard * pasteboard = [NSPasteboard generalPasteboard];
+    NSData * object = NULL;
+
+    struct image img;
+    img.kind = 0;
+    img.bytes = NULL;
+    img.length = 0;
+
+    /*NSURL * url = [NSURL URLFromPasteboard:pasteboard];
+    if (url == NULL) {
+        return img;
+    }* /
+
+    if ((object = [pasteboard dataForType:NSFilenamesPboardType]) != NULL) {
+        NSArray * filenames = [pasteboard propertyListForType:NSFilenamesPboardType];
+
+        NSLog(@"filenames = %@", filenames);
+
+        img.kind = 77;
+    }
+
+    return img;
+}*/
+
+struct files get_clipboard_files() {
+    NSPasteboard * pasteboard = [NSPasteboard generalPasteboard];
+    NSData * object = NULL;
+
+    struct files files;
+    files.names = NULL;
+    files.count = 0;
+
+    if ((object = [pasteboard dataForType:NSFilenamesPboardType]) != NULL) {
+        NSArray * filenames = [pasteboard propertyListForType:NSFilenamesPboardType];
+
+        NSLog(@"filenames = %@", filenames);
+
+        const int count = [filenames count];
+        if (count) {
+            NSEnumerator * e = [filenames objectEnumerator];
+            char ** names = calloc(count, sizeof(char*));
+            for (int i = 0; i < count; i++) {
+                names[i] = strdup([[e nextObject] UTF8String]);
+            }
+
+            files.names = (const char**)(names);
+            files.count = count;
+
+            // TODO: Fix memory leak.
+            /*for (i = 0; i < count; i++)
+                free(names[i]);
+            free(names);*/
+        }
+    }
+
+    return files;
+}
+
+/*void get_clipboard_content() {
+    struct image img;
+    img.kind = 0;
+    img.bytes = NULL;
+    img.length = 0;
+
+    // TODO: Fix memory leak.
+    if ([[pasteboard types] containsObject:NSFilenamesPboardType] &&
+        (object = [pasteboard dataForType:NSFilenamesPboardType]) != NULL) {
+
+        //NSArray * filenames = [pasteboard propertyListForType:NSFilenamesPboardType];
+
+        NSLog(@"stringForType = %@", [pasteboard stringForType:NSFilenamesPboardType]);
+
+        img.kind = 56;
+    } else if ([[pasteboard types] containsObject:NSPasteboardTypePNG] &&
+        (object = [pasteboard dataForType:NSPasteboardTypePNG]) != NULL) {
+
+        img.kind = IMAGE_KIND_PNG;
+        img.bytes = [object bytes];
+        img.length = [object length];
+    } else if ([[pasteboard types] containsObject:NSPasteboardTypeTIFF] &&
+        (object = [pasteboard dataForType:NSPasteboardTypeTIFF]) != NULL) {
+
+        img.kind = IMAGE_KIND_TIFF;
+        img.bytes = [object bytes];
+        img.length = [object length];
+    }
+}*/
 
 void display_notification(int notificationId, const char * title, const char * body, struct image img, double timeout) {
     NSUserNotification * notification = [[NSUserNotification alloc] init];

--- a/platform/darwin/tray.m
+++ b/platform/darwin/tray.m
@@ -155,8 +155,6 @@ struct clipboard_content get_clipboard_content() {
     if ([[pasteboard types] containsObject:NSFilenamesPboardType] &&
         (filenames = [pasteboard propertyListForType:NSFilenamesPboardType]) != NULL) {
 
-        //NSLog(@"filenames = %@", filenames);
-
         const int count = [filenames count];
         if (count) {
             NSEnumerator * e = [filenames objectEnumerator];

--- a/trayhost.go
+++ b/trayhost.go
@@ -127,6 +127,28 @@ func GetClipboardImage() (Image, error) {
 	return Image{Kind: ImageKind(img.kind), Bytes: C.GoBytes(img.bytes, img.length)}, nil
 }
 
+/*func GetClipboardFile() (Image, error) {
+	img := C.get_clipboard_file()
+	if img.kind == 0 {
+		return Image{}, errors.New("Can't get clipboard file.")
+	}
+
+	return Image{Kind: ImageKind(img.kind), Bytes: C.GoBytes(img.bytes, img.length)}, nil
+}*/
+
+func GetClipboardFiles() ([]string, error) {
+	files := C.get_clipboard_files()
+
+	namesSlice := make([]string, int(files.count))
+	for i := 0; i < int(files.count); i++ {
+		var x *C.char
+		p := (**C.char)(unsafe.Pointer(uintptr(unsafe.Pointer(files.names)) + uintptr(i)*unsafe.Sizeof(x)))
+		namesSlice[i] = C.GoString(*p)
+	}
+
+	return namesSlice, nil
+}
+
 // ---
 
 // TODO: Garbage collection. Really only need this until the notification is cleared, so its Handler is accessible.

--- a/trayhost.go
+++ b/trayhost.go
@@ -107,11 +107,13 @@ const (
 	ImageKindNone ImageKind = iota
 	ImageKindPng
 	ImageKindTiff
+	ImageKindMov
 )
 
 type Image struct {
-	Kind  ImageKind
-	Bytes []byte
+	Kind        ImageKind // TODO: Remove in favour of ContentType.
+	ContentType string
+	Bytes       []byte
 }
 
 // GetClipboardString returns the contents of the system clipboard, if it

--- a/trayhost.go
+++ b/trayhost.go
@@ -23,13 +23,24 @@ import "C"
 
 var menuItems []MenuItem
 
+// MenuItem is a menu item.
 type MenuItem struct {
-	Title   string
-	Enabled func() bool // nil means always enabled.
+	// Title is the title of menu item.
+	//
+	// If empty, it acts as a separator. SeparatorMenuItem can be used
+	// to create such separator menu items.
+	Title string
+
+	// Enabled can optionally control if this menu item is enabled or disabled.
+	//
+	// nil means always enabled.
+	Enabled func() bool
+
+	// Handler is triggered when the item is activated. nil means no handler.
 	Handler func()
 }
 
-// Run the host system's event loop.
+// Initialize sets up the application properties.
 func Initialize(title string, imageData []byte, items []MenuItem) {
 	cTitle := C.CString(title)
 	defer C.free(unsafe.Pointer(cTitle))
@@ -45,15 +56,17 @@ func Initialize(title string, imageData []byte, items []MenuItem) {
 	}
 }
 
+// EnterLoop enters main loop.
 func EnterLoop() {
 	C.native_loop()
 }
 
+// Exit exits the application. It can be called from a MenuItem handler.
 func Exit() {
 	C.exit_loop()
 }
 
-// Creates a separator MenuItem.
+// SeparatorMenuItem creates a separator MenuItem.
 func SeparatorMenuItem() MenuItem { return MenuItem{Title: ""} }
 
 func addItem(id int, item MenuItem) {
@@ -72,9 +85,8 @@ func cAddMenuItem(id C.int, title *C.char, disabled C.int) {
 func cbool(b bool) C.int {
 	if b {
 		return 1
-	} else {
-		return 0
 	}
+	return 0
 }
 
 // ---
@@ -83,21 +95,23 @@ func cbool(b bool) C.int {
 // string.
 //
 // This function may only be called from the main thread.
-func SetClipboardText(str string) {
-	cp := C.CString(str)
+func SetClipboardText(text string) {
+	cp := C.CString(text)
 	defer C.free(unsafe.Pointer(cp))
 
 	C.set_clipboard_string(cp)
 }
 
-// File extension in lower case: "png", "jpg", "tiff", etc. Empty string means no image.
+// ImageKind is a file extension in lower case: "png", "jpg", "tiff", etc. Empty string means no image.
 type ImageKind string
 
+// Image is an encoded image of certain kind.
 type Image struct {
 	Kind  ImageKind
 	Bytes []byte
 }
 
+// ClipboardContent holds the contents of system clipboard.
 type ClipboardContent struct {
 	Text  string
 	Image Image
@@ -150,6 +164,8 @@ type Notification struct {
 	Timeout time.Duration
 
 	// Activation (click) handler.
+	//
+	// nil means no handler.
 	Handler func()
 }
 

--- a/trayhost_exports.go
+++ b/trayhost_exports.go
@@ -50,17 +50,19 @@ func notification_callback(notificationId C.int) {
 }
 
 func create_image(image Image) (C.struct_image, func()) {
-	img := C.struct_image{
-		kind: C.char(image.Kind),
-	}
+	var img C.struct_image
 
-	if len(image.Bytes) == 0 {
+	if image.Kind == "" || len(image.Bytes) == 0 {
 		return img, func() {}
 	}
 
 	// Copy the image data into unmanaged memory.
+	cImageKind := C.CString(string(image.Kind))
 	cImageData := C.malloc(C.size_t(len(image.Bytes)))
-	freeImg := func() { C.free(cImageData) }
+	freeImg := func() {
+		C.free(unsafe.Pointer(cImageKind))
+		C.free(cImageData)
+	}
 	var cImageDataSlice []C.uchar
 	sliceHeader := (*reflect.SliceHeader)(unsafe.Pointer(&cImageDataSlice))
 	sliceHeader.Cap = len(image.Bytes)
@@ -70,6 +72,7 @@ func create_image(image Image) (C.struct_image, func()) {
 		cImageDataSlice[i] = C.uchar(b)
 	}
 
+	img.kind = cImageKind
 	img.bytes = unsafe.Pointer(&cImageDataSlice[0])
 	img.length = C.int(len(image.Bytes))
 
@@ -79,7 +82,7 @@ func create_image(image Image) (C.struct_image, func()) {
 //export invert_png_image
 func invert_png_image(img C.struct_image) C.struct_image {
 	imageData := invertPngImage(C.GoBytes(img.bytes, img.length))
-	img, _ = create_image(Image{Kind: ImageKindPng, Bytes: imageData})
+	img, _ = create_image(Image{Kind: "png", Bytes: imageData})
 	return img
 }
 

--- a/trayhost_exports.go
+++ b/trayhost_exports.go
@@ -92,7 +92,7 @@ func invertPngImage(imageData []byte) []byte {
 		panic(err)
 	}
 
-	InvertImageNrgba(m.(*image.NRGBA))
+	invertImageNrgba(m.(*image.NRGBA))
 
 	var buf bytes.Buffer
 	err = png.Encode(&buf, m)
@@ -103,7 +103,7 @@ func invertPngImage(imageData []byte) []byte {
 	return buf.Bytes()
 }
 
-func InvertImageNrgba(nrgba *image.NRGBA) {
+func invertImageNrgba(nrgba *image.NRGBA) {
 	bounds := nrgba.Bounds()
 	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
 		for x := bounds.Min.X; x < bounds.Max.X; x++ {


### PR DESCRIPTION
This is needed to close https://github.com/pavben/InstantShare/issues/9.

**Updated:** Switch to a combined `func GetClipboardContent() (ClipboardContent, error)` method. It returns the contents of the system clipboard.

```Go
type ClipboardContent struct {
    Text  string
    Image Image
    Files []string
}
```

~~The `GetClipboardFiles() []string` method returns the filepaths to files that are copied to clipboard, if any.~~

~~E.g.,~~

~~`GetClipboardFiles(): [/Users/Dmitri/Local/OSes/ubuntu-14.04-desktop-amd64.iso /Users/Dmitri/Local/OSes/ubuntu-12.04.2-server-amd64.iso] len(2) <nil>`~~