### PR TITLE
platform/darwin: Make NSStatusItem image a template.

### DIFF
--- a/platform/darwin/tray.m
+++ b/platform/darwin/tray.m
@@ -6,7 +6,6 @@ char * clipboardString;
 extern void tray_callback(int itemId);
 extern BOOL tray_enabled(int itemId);
 extern void notification_callback();
-extern struct image invert_png_image(struct image img);
 
 @interface ManageHandler : NSObject<NSUserNotificationCenterDelegate>
 - (void)manage:(id)sender;
@@ -116,17 +115,11 @@ int init(const char * title, struct image img) {
     NSImage * icon = [[NSImage alloc] initWithSize:iconSize];
     NSData * iconData = [NSData dataWithBytes:img.bytes length:img.length];
     [icon addRepresentation:[NSBitmapImageRep imageRepWithData:iconData]];
-
-    img = invert_png_image(img);
-
-    NSImage * icon2 = [[NSImage alloc] initWithSize:iconSize];
-    NSData * icon2Data = [NSData dataWithBytes:img.bytes length:img.length];
-    [icon2 addRepresentation:[NSBitmapImageRep imageRepWithData:icon2Data]];
+    [icon setTemplate:YES];
 
     NSStatusItem * statusItem = [[[NSStatusBar systemStatusBar] statusItemWithLength:NSSquareStatusItemLength] retain];
     [statusItem setMenu:appMenu];
     [statusItem setImage:icon];
-    [statusItem setAlternateImage:icon2];
     [statusItem setHighlightMode:YES];
     [statusItem setToolTip:[NSString stringWithUTF8String:title]];
 

--- a/trayhost.go
+++ b/trayhost.go
@@ -41,6 +41,7 @@ type MenuItem struct {
 }
 
 // Initialize sets up the application properties.
+// imageData is the icon image in PNG format.
 func Initialize(title string, imageData []byte, items []MenuItem) {
 	cTitle := C.CString(title)
 	defer C.free(unsafe.Pointer(cTitle))

--- a/trayhost_exports.go
+++ b/trayhost_exports.go
@@ -1,10 +1,6 @@
 package trayhost
 
 import (
-	"bytes"
-	"image"
-	"image/color"
-	"image/png"
 	"log"
 	"reflect"
 	"unsafe"
@@ -77,41 +73,4 @@ func create_image(image Image) (C.struct_image, func()) {
 	img.length = C.int(len(image.Bytes))
 
 	return img, freeImg
-}
-
-//export invert_png_image
-func invert_png_image(img C.struct_image) C.struct_image {
-	imageData := invertPngImage(C.GoBytes(img.bytes, img.length))
-	img, _ = create_image(Image{Kind: "png", Bytes: imageData})
-	return img
-}
-
-func invertPngImage(imageData []byte) []byte {
-	m, _, err := image.Decode(bytes.NewReader(imageData))
-	if err != nil {
-		panic(err)
-	}
-
-	invertImageNrgba(m.(*image.NRGBA))
-
-	var buf bytes.Buffer
-	err = png.Encode(&buf, m)
-	if err != nil {
-		panic(err)
-	}
-
-	return buf.Bytes()
-}
-
-func invertImageNrgba(nrgba *image.NRGBA) {
-	bounds := nrgba.Bounds()
-	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
-		for x := bounds.Min.X; x < bounds.Max.X; x++ {
-			c := nrgba.At(x, y).(color.NRGBA)
-			c.R = 255 - c.R
-			c.G = 255 - c.G
-			c.B = 255 - c.B
-			nrgba.SetNRGBA(x, y, c)
-		}
-	}
 }


### PR DESCRIPTION
This removes the need to manually compute and set an alternate image.

This allows trayhost to work as expected on macOS 10.14 when using Dark Mode.

References:

-	https://developer.apple.com/documentation/appkit/supporting_dark_mode_in_your_interface
-	https://developer.apple.com/documentation/appkit/images_and_pdf/providing_images_for_different_appearances
-	https://stackoverflow.com/questions/24623559/nsstatusitem-change-image-for-dark-tint/24644754#24644754

Fixes pavben/InstantShare#32.